### PR TITLE
Updating django-imgix to support imgix 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This app requires Django > 1.4 and imgix>0.1
 
 
 1. Run ```  pip install django-imgix  ```
-2. Add ``` 'django-imgix' ``` to your ``` INSTALLED_APPS ```:
+2. Add ``` 'django_imgix' ``` to your ``` INSTALLED_APPS ```:
 
 
 
@@ -22,7 +22,7 @@ This app requires Django > 1.4 and imgix>0.1
 ```
 	INSTALLED_APPS = (
 		...
-		'django-imgix',
+		'django_imgix',
 	)
 ```
 

--- a/django_imgix/templatetags/imgix_tags.py
+++ b/django_imgix/templatetags/imgix_tags.py
@@ -183,5 +183,5 @@ def get_imgix(image_url, alias=None, wh=None, **kwargs):
     image_url = urlparse(image_url).path
 
     # Build the Imgix URL
-    url = builder.create_url(image_url, **arguments)
+    url = builder.create_url(image_url, arguments)
     return url

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-imgix',
-    version='0.1',
+    version='0.2',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',  # example license
@@ -20,7 +20,7 @@ setup(
     author_email='devops@pancentric.com',
     install_requires=[
         'django>=1.4.0',
-        'imgix>=0.2.0',
+        'imgix>=1.0.0',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
Imgix updated their python lib to accept only dicts now, not kwargs. I've submitted a patch for this and a few others:
- bumped version to 0.2
- updated setup.py to depend on imgix 1.0.0
- updated readme

cheers!
