### PR TITLE
Mark tag generated URL as safe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ python: 2.7
 install:
   - pip install tox
 env:
-  - TOXENV=py26-django1.4
   - TOXENV=py27-django1.4
   - TOXENV=py27-django1.7
   - TOXENV=py34-django1.7
   - TOXENV=py27-django1.8
   - TOXENV=py34-django1.8
+  - TOXENV=py27-django1.11
+  - TOXENV=py34-django1.11
+  - TOXENV=py34-django2.0
 script:
   - tox -e $TOXENV

--- a/django_imgix/templatetags/imgix_tags.py
+++ b/django_imgix/templatetags/imgix_tags.py
@@ -12,6 +12,10 @@ from django.template import TemplateSyntaxError
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django import template
+try:
+    from django.utils.safestring import mark_safe
+except ImportError:
+    mark_safe = lambda s: s
 
 import imgix
 
@@ -189,4 +193,4 @@ def get_imgix(image_url, alias=None, wh=None, **kwargs):
 
     # Build the Imgix URL
     url = builder.create_url(image_url, arguments)
-    return url
+    return mark_safe(url)

--- a/django_imgix/tests/settings.py
+++ b/django_imgix/tests/settings.py
@@ -7,6 +7,19 @@ MEDIA_URL = '/media/'
 
 DATABASE_ENGINE = 'sqlite3'
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                "django.contrib.auth.context_processors.auth",
+            ],
+        },
+    },
+]
+
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = 
-    py26-django1.4,
+envlist =
     py27-django1.4,
     py27-django1.7,
     py34-django1.7,
     py27-django1.8,
     py34-django1.8,
+    py27-django1.11,
+    py34-django1.11,
+    py34-django2.0,
     coverage,
     docs
 
@@ -15,11 +17,6 @@ setenv =
     PYTHONPATH = {toxinidir}
 commands =
     django-admin.py test django_imgix
-
-[testenv:py26-django1.4]
-basepython = python2.6
-deps =
-    Django>=1.4,<1.5
 
 [testenv:py27-django1.4]
 basepython = python2.7
@@ -45,6 +42,21 @@ deps =
 basepython = python3.4
 deps =
     Django>=1.8,<1.9
+
+[testenv:py27-django1.11]
+basepython = python2.7
+deps =
+    Django>=1.11,<2.0
+
+[testenv:py34-django1.11]
+basepython = python3.4
+deps =
+    Django>=1.11,<2.0
+
+[testenv:py34-django2.0]
+basepython = python3.4
+deps =
+    django>=2.0,<2.1
 
 [testenv:coverage]
 basepython = python2.7


### PR DESCRIPTION
If autoescape is enabled, the URL gets escaped, resulting in URLs like:
```
https://test1.imgix.net/media/image/image_0001.jpg?h=768&amp;w=1024
```
To ensure the tag generated URL isn't escaped, this PR marks the URL string safe before returning to the template.